### PR TITLE
parametrization of project

### DIFF
--- a/build.py
+++ b/build.py
@@ -2,6 +2,11 @@ import os
 import platform
 import shutil
 
+############# CONFIGURATION ###########################
+shared = False
+charmander_header = False
+#######################################################
+
 def run(cmd):
     ret = os.system(cmd)
     if ret != 0:
@@ -23,19 +28,37 @@ project_base_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "pr
 
 dep_dirs = [f'-D{project.capitalize()}_ROOT="{install_dir}/{project}"' for project in projects]
 
+
+shared_cmake = "-DBUILD_SHARED_LIBS=ON" if shared else ""
+shared_conan = '-o "*:shared=True"' if shared else ""
+
+charmander_header_cmake = "-DCHARMANDER_HEADER_ONLY=ON" if charmander_header else ""
+charmander_header_conan = '-o "*:header_only=True"' if charmander_header else ""
+
+print("***********************************************************")
+print("********************** CMakeDeps **************************")
+print("***********************************************************")
+# Build using Conan CMakeDeps
+for project in projects:
+    run(f"conan create projects/{project} {shared_conan} {charmander_header_conan}")
+
+
+print("***********************************************************")
+print("********************** Pure CMAKE *************************")
+print("***********************************************************")
 # Build projects and use vanilla CMake-generated config and targets (no Conan involved)
 for project in projects:
     defines = " ".join(dep_dirs)
     print(f"-----------------Project: {project}-----------------")
-    run(f"cmake --fresh -S {project_base_dir}/{project} -B {build_dir}/{project} -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX={install_dir}/{project} {defines}")
+    run(f"cmake --fresh -S {project_base_dir}/{project} -B {build_dir}/{project} -DCMAKE_BUILD_TYPE=Release "
+        f"-DCMAKE_INSTALL_PREFIX={install_dir}/{project} {defines} {shared_cmake} {charmander_header_cmake}")
     run(f"cmake --build {build_dir}/{project} --config Release")
     run(f"cmake --install {build_dir}/{project} --config Release")
 
 
-# Build using Conan CMakeDeps
-for project in projects:
-    run(f"conan create projects/{project}")
-
+print("***********************************************************")
+print("******************** NEW CMakeDeps ************************")
+print("***********************************************************")
 # Build using Conan new experimental CMakeDeps
 for project in projects:
-    run(f"conan create projects/{project} -c tools.cmake.cmakedeps:new=will_break_next")
+    run(f"conan create projects/{project} {shared_conan} {charmander_header_conan} -c tools.cmake.cmakedeps:new=will_break_next")

--- a/projects/bulbasaur/CMakeLists.txt
+++ b/projects/bulbasaur/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(Charmander REQUIRED)
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
-add_library(bulbasaur SHARED bulbasaur.cpp)
+add_library(bulbasaur bulbasaur.cpp)
 
 target_include_directories(bulbasaur
     PUBLIC

--- a/projects/bulbasaur/conanfile.py
+++ b/projects/bulbasaur/conanfile.py
@@ -6,10 +6,12 @@ import os
 class pikachuRecipe(ConanFile):
     name = "bulbasaur"
     version = "1.0"
-    package_type = "shared-library"
+    package_type = "library"
 
     # Binary configuration
     settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [False, True]}
+    default_options = {"shared": False}
 
     # Sources are located in the same place as this recipe, copy them to the recipe
     exports_sources = "CMakeLists.txt", "bulbasaur.cpp", "include/*", "BulbasaurConfig.cmake.in", "hello-bulbasaur.cpp"

--- a/projects/charmander/CMakeLists.txt
+++ b/projects/charmander/CMakeLists.txt
@@ -8,15 +8,21 @@ find_package(Pikachu REQUIRED)
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
-add_library(charmander SHARED charmander.cpp)
+if(CHARMANDER_HEADER_ONLY)
+    add_compile_definitions(CHARMANDER_HEADER_ONLY)
+    add_library(charmander INTERFACE)
+    target_link_libraries(charmander INTERFACE Pikachu::pikachu)
+else()
+    add_library(charmander charmander.cpp)
 
-target_include_directories(charmander
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:include> # see below
-)
+    target_include_directories(charmander
+        PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:include> # see below
+    )
 
-target_link_libraries(charmander PRIVATE Pikachu::pikachu)
+    target_link_libraries(charmander PRIVATE Pikachu::pikachu)
+endif()
 
 target_sources(charmander
     PUBLIC

--- a/projects/charmander/conanfile.py
+++ b/projects/charmander/conanfile.py
@@ -6,10 +6,16 @@ import os
 class pikachuRecipe(ConanFile):
     name = "charmander"
     version = "1.0"
-    package_type = "shared-library"
+    package_type = "library"
 
     # Binary configuration
     settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [False, True],
+               "header_only": [False, True]}
+    default_options = {"shared": False,
+                       "header_only": False}
+    implements = ["auto_shared_fpic", "auto_header_only"]
+
 
     # Sources are located in the same place as this recipe, copy them to the recipe
     exports_sources = "CMakeLists.txt", "charmander.cpp", "include/*", "CharmanderConfig.cmake.in"
@@ -24,6 +30,8 @@ class pikachuRecipe(ConanFile):
         deps = CMakeDeps(self)
         deps.generate()
         tc = CMakeToolchain(self)
+        if self.options.header_only:
+            tc.cache_variables["CHARMANDER_HEADER_ONLY"] = "ON"
         tc.generate()
 
     def build(self):

--- a/projects/charmander/include/charmander.h
+++ b/projects/charmander/include/charmander.h
@@ -1,6 +1,15 @@
 #pragma once
 #include <string>
+#ifdef CHARMANDER_HEADER_ONLY
+#endif
 
 namespace charmander {
+    #ifdef CHARMANDER_HEADER_ONLY
+    void say_hello(const std::string& name) {
+        std::cout << "Hello, " << name << "! - Charmander" << std::endl;
+        pikachu::say_hello(name);       
+    }
+    #else
     void say_hello(const std::string& name);
+    #endif
 }

--- a/projects/pikachu/CMakeLists.txt
+++ b/projects/pikachu/CMakeLists.txt
@@ -5,7 +5,7 @@ include(GNUInstallDirs)
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
-add_library(pikachu SHARED pikachu.cpp)
+add_library(pikachu pikachu.cpp)
 
 target_include_directories(pikachu
     PUBLIC

--- a/projects/pikachu/conanfile.py
+++ b/projects/pikachu/conanfile.py
@@ -6,10 +6,12 @@ import os
 class pikachuRecipe(ConanFile):
     name = "pikachu"
     version = "1.0"
-    package_type = "shared-library"
+    package_type = "library"
 
     # Binary configuration
     settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [False, True]}
+    default_options = {"shared": False}
 
     # Sources are located in the same place as this recipe, copy them to the recipe
     exports_sources = "CMakeLists.txt", "pikachu.cpp", "include/*", "PikachuConfig.cmake.in"


### PR DESCRIPTION
Injecting the possibiliby to chose:
- shared/static for all packages, both with Conan and in Pure CMake 
- header-only for Charmander, both with Conan and with pure CMake

Controlled by variables in the build.py:

```python
############# CONFIGURATION ###########################
shared = False
charmander_header = False
#######################################################
```

It works both for shared=False and shared=True in Windows and Linux

But setting ``charmander_header=True`` works with classic ``CMakeDeps``, but fails with the pure CMake project.